### PR TITLE
Add "like anime" feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,5 @@ anicli-esp --config
 ```
 ## Interfaz
 Con el tabulador y shift + tabulador se puede cambiar la ventana seleccionada. El enter permite selecionar una opción.
+## Likes
+Con la tecla l pudes añadir un anime a la lista de animes que te gustan. A la cual puedes acceder presionando ctrl+l

--- a/src/app.rs
+++ b/src/app.rs
@@ -80,6 +80,11 @@ impl App<'_> {
             {
                 self.exit = true
             }
+            // Ver likeados con CRT+L
+            KeyCode::Char('l') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.handle_continue_watching()
+            }
+            KeyCode::Char('l') => self.handle_like(),
             KeyCode::BackTab => self.change_focus_backwards(),
             KeyCode::Tab => self.change_focus_forward(),
             KeyCode::Enter => self.handle_enter(),
@@ -100,6 +105,21 @@ impl App<'_> {
             Focus::Input => self.handle_enter_input(),
             Focus::List => self.handle_enter_list(),
             _ => (),
+        }
+    }
+
+    fn handle_continue_watching(&mut self) {
+        if let Ok(config) = CONFIG.try_read() {
+            let continue_watching_anime_list = config.get_liked_animes();
+            self.list.set_contents(continue_watching_anime_list);
+            self.stage = Stage::SeriesSelect;
+            self.input.clear();
+        }
+    }
+
+    fn handle_like(&mut self) {
+        if let Some(current_selected) = self.list.current_value() {
+            CONFIG.write().unwrap().toggle_like(current_selected);
         }
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -118,7 +118,7 @@ impl App<'_> {
             .set_contents(liked_animes.iter().cloned().collect());
         self.stage = Stage::SeriesSelect;
         self.input.clear();
-        self.change_focus_forward();
+        self.set_focus(Focus::List);
     }
 
     fn handle_series_like(&mut self) {
@@ -223,6 +223,33 @@ impl App<'_> {
                 }
             }
         }
+    }
+
+    fn set_focus(&mut self, focus: Focus) {
+        match self.focus {
+            Focus::Input => {
+                self.input.defocus();
+            }
+            Focus::List => {
+                self.list.defocus();
+            }
+            Focus::Servers => {
+                self.servers.defocus();
+            }
+        }
+
+        match focus {
+            Focus::Input => {
+                self.input.focus();
+            }
+            Focus::List => {
+                self.list.focus();
+            }
+            Focus::Servers => {
+                self.servers.focus();
+            }
+        }
+        self.focus = focus;
     }
 
     fn change_focus_forward(&mut self) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,6 +29,7 @@ pub struct Config {
     client: Server,
     frontend: Frontend,
     log_file_path: PathBuf,
+    liked_animes: Vec<String>,
 }
 
 impl Config {
@@ -49,6 +50,7 @@ impl Config {
             client: Server::AnimeFlv,
             frontend: Frontend::DefaultBrowser,
             log_file_path: PathBuf::new(),
+            liked_animes: Vec::new(),
         })
     }
 
@@ -64,6 +66,24 @@ impl Config {
 
     pub fn get_log_file(&self) -> &PathBuf {
         &self.log_file_path
+    }
+    pub fn get_liked_animes(&self) -> Vec<String> {
+        return self.liked_animes.clone();
+    }
+
+    pub fn toggle_like(&mut self, current_selected: String) {
+        if let Some(anime_index) = self
+            .liked_animes
+            .iter()
+            .enumerate()
+            .find(|(_, a)| **a == current_selected)
+            .map(|(i, _)| i)
+        {
+            self.liked_animes.remove(anime_index);
+        } else {
+            self.liked_animes.push(current_selected);
+        }
+        self.save();
     }
 
     fn save(&mut self) {
@@ -140,6 +160,7 @@ impl ConfigApp {
             client: Server::AnimeFlv,
             frontend: self.run_select_frontend(terminal)?,
             log_file_path: dirs.data_dir().join("logs"),
+            liked_animes: Vec::new(),
         });
 
         Ok(())

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,7 @@ use ratatui::widgets::ListState;
 use ratatui::widgets::Paragraph;
 use ratatui::DefaultTerminal;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
 use std::path::PathBuf;
 use std::sync::RwLock;
 
@@ -29,7 +30,7 @@ pub struct Config {
     client: Server,
     frontend: Frontend,
     log_file_path: PathBuf,
-    liked_animes: Vec<String>,
+    liked_animes: BTreeSet<String>,
 }
 
 impl Config {
@@ -50,7 +51,7 @@ impl Config {
             client: Server::AnimeFlv,
             frontend: Frontend::DefaultBrowser,
             log_file_path: PathBuf::new(),
-            liked_animes: Vec::new(),
+            liked_animes: BTreeSet::new(),
         })
     }
 
@@ -67,22 +68,15 @@ impl Config {
     pub fn get_log_file(&self) -> &PathBuf {
         &self.log_file_path
     }
-    pub fn get_liked_animes(&self) -> Vec<String> {
-        return self.liked_animes.clone();
+    pub fn get_liked_animes(&self) -> &BTreeSet<String> {
+        &self.liked_animes
     }
 
-    pub fn toggle_like(&mut self, current_selected: String) {
-        if let Some(anime_index) = self
-            .liked_animes
-            .iter()
-            .enumerate()
-            .find(|(_, a)| **a == current_selected)
-            .map(|(i, _)| i)
-        {
-            self.liked_animes.remove(anime_index);
-        } else {
-            self.liked_animes.push(current_selected);
+    pub fn toggle_like(&mut self, series: String) {
+        if !self.liked_animes.remove(&series) {
+            self.liked_animes.insert(series);
         }
+
         self.save();
     }
 
@@ -160,7 +154,7 @@ impl ConfigApp {
             client: Server::AnimeFlv,
             frontend: self.run_select_frontend(terminal)?,
             log_file_path: dirs.data_dir().join("logs"),
-            liked_animes: Vec::new(),
+            liked_animes: BTreeSet::new(),
         });
 
         Ok(())

--- a/src/list.rs
+++ b/src/list.rs
@@ -4,6 +4,8 @@ use ratatui::{
     widgets::{Block, Borders, List, ListItem, ListState},
 };
 
+use crate::config::CONFIG;
+
 #[derive(Default)]
 pub struct OptionsList<'list_contents> {
     contents: Vec<ListItem<'list_contents>>,
@@ -25,7 +27,11 @@ impl<'list_contents> OptionsList<'list_contents> {
     pub fn set_contents(&mut self, contents: Vec<String>) {
         let contents = contents
             .into_iter()
-            .map(|tittle| {
+            .map(|mut tittle| {
+                if CONFIG.read().unwrap().get_liked_animes().contains(&tittle) {
+                    tittle.push_str(" ★");
+                }
+
                 // Luego borro los viejos
                 &*Box::leak(tittle.into_boxed_str())
             })
@@ -70,12 +76,26 @@ impl<'list_contents> OptionsList<'list_contents> {
         self.list_state.selected()
     }
 
+    pub fn select(&mut self, idx: Option<usize>) {
+        self.list_state.select(idx);
+    }
+
     pub fn current_value(&self) -> Option<String> {
         if let Some(idx) = self.list_state.selected() {
+            let contents = self.contents_texts[idx]
+                .strip_suffix(" ★")
+                .unwrap_or(&self.contents_texts[idx]);
             // La referencia puede ser dropeada antes
-            return Some(self.contents_texts[idx].to_owned());
+            return Some(contents.to_owned());
         }
         None
+    }
+
+    pub fn get_contents(&self) -> Vec<String> {
+        self.contents_texts
+            .iter()
+            .map(|entry| entry.strip_suffix(" ★").unwrap_or(entry).to_owned())
+            .collect()
     }
 }
 


### PR DESCRIPTION
## Keyboard shortcuts for "Like" functionality

**New shortcuts:**
- `L` → Toggle like on selected anime
- `Ctrl+L` → Show only liked animes

**Why:** Improve UX by making it easier to track and continue watching non-ended animes.

**Changes:**
- Added like toggle functionality
- Implemented liked animes filter
- Intuitive keyboard shortcuts

**⚠️ Warning:** Requires deleting `config.json` file, otherwise the application will freeze on startup.